### PR TITLE
feat(admin): Scaffold admin dashboard and subsection pages

### DIFF
--- a/src/data/admin.ts
+++ b/src/data/admin.ts
@@ -1,0 +1,513 @@
+/**
+ * Admin Data
+ * 
+ * Mock data for the administrator dashboard including system statistics,
+ * crawler configurations, and API settings.
+ */
+
+// System statistics for admin dashboard
+export const systemStats = [
+  { 
+    label: 'Companies', 
+    value: 2847, 
+    change: '+12%', 
+    trend: 'up',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5"><path fill-rule="evenodd" d="M4.5 2.25a.75.75 0 0 0 0 1.5v16.5h-.75a.75.75 0 0 0 0 1.5h16.5a.75.75 0 0 0 0-1.5h-.75V3.75a.75.75 0 0 0 0-1.5h-15ZM9 6a.75.75 0 0 0 0 1.5h1.5a.75.75 0 0 0 0-1.5H9Zm-.75 3.75A.75.75 0 0 1 9 9h1.5a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM9 12a.75.75 0 0 0 0 1.5h1.5a.75.75 0 0 0 0-1.5H9Zm3.75-5.25A.75.75 0 0 1 13.5 6H15a.75.75 0 0 1 0 1.5h-1.5a.75.75 0 0 1-.75-.75ZM13.5 9a.75.75 0 0 0 0 1.5H15A.75.75 0 0 0 15 9h-1.5Zm-.75 3.75a.75.75 0 0 1 .75-.75H15a.75.75 0 0 1 0 1.5h-1.5a.75.75 0 0 1-.75-.75ZM9 19.5v-2.25a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-.75.75h-4.5A.75.75 0 0 1 9 19.5Z" clip-rule="evenodd" /></svg>'
+  },
+  { 
+    label: 'Products', 
+    value: 14382, 
+    change: '+8%', 
+    trend: 'up',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5"><path d="M11.25 3v4.046a3 3 0 0 0-4.277 4.204H1.5v-6A2.25 2.25 0 0 1 3.75 3h7.5ZM12.75 3h7.5A2.25 2.25 0 0 1 22.5 5.25v6h-5.473a3 3 0 0 0-4.277-4.204V3ZM1.5 15.75v-1.5h4.973a3 3 0 0 0 4.277 4.204V21h-7.5a2.25 2.25 0 0 1-2.25-2.25v-3ZM12.75 21v-2.546a3 3 0 0 0 4.277-4.204H22.5v1.5A2.25 2.25 0 0 1 20.25 21h-7.5Z" /></svg>'
+  },
+  { 
+    label: 'Websites', 
+    value: 9271, 
+    change: '+15%', 
+    trend: 'up',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5"><path d="M21.721 12.752a9.711 9.711 0 0 0-.945-5.003 12.754 12.754 0 0 1-4.339 2.708 18.991 18.991 0 0 1-.214 4.772 17.165 17.165 0 0 0 5.498-2.477ZM14.634 15.55a17.324 17.324 0 0 0 .332-4.647c-.952.227-1.945.347-2.966.347-1.021 0-2.014-.12-2.966-.347a17.515 17.515 0 0 0 .332 4.647 17.385 17.385 0 0 0 5.268 0ZM9.772 17.119a18.963 18.963 0 0 0 4.456 0A17.182 17.182 0 0 1 12 21.724a17.18 17.18 0 0 1-2.228-4.605ZM7.777 15.23a18.87 18.87 0 0 1-.214-4.774 12.753 12.753 0 0 1-4.34-2.708 9.711 9.711 0 0 0-.944 5.004 17.165 17.165 0 0 0 5.498 2.477ZM21.356 14.752a9.765 9.765 0 0 1-7.478 6.817 18.64 18.64 0 0 0 1.988-4.718 18.627 18.627 0 0 0 5.49-2.098ZM2.644 14.752c1.682.971 3.53 1.688 5.49 2.099a18.64 18.64 0 0 0 1.988 4.718 9.765 9.765 0 0 1-7.478-6.816ZM13.878 2.43a9.755 9.755 0 0 1 6.116 3.986 11.267 11.267 0 0 1-3.746 2.504 18.63 18.63 0 0 0-2.37-6.49ZM12 2.276a17.152 17.152 0 0 1 2.805 7.121c-.897.23-1.837.353-2.805.353-.968 0-1.908-.122-2.805-.353A17.151 17.151 0 0 1 12 2.276ZM10.122 2.43a18.629 18.629 0 0 0-2.37 6.49 11.266 11.266 0 0 1-3.746-2.504 9.754 9.754 0 0 1 6.116-3.985Z" /></svg>'
+  },
+  { 
+    label: 'API Calls', 
+    value: 237580, 
+    change: '+24%', 
+    trend: 'up',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5"><path fill-rule="evenodd" d="M14.447 3.026a.75.75 0 0 1 .527.921l-4.5 16.5a.75.75 0 0 1-1.448-.394l4.5-16.5a.75.75 0 0 1 .921-.527ZM16.72 6.22a.75.75 0 0 1 1.06 0l5.25 5.25a.75.75 0 0 1 0 1.06l-5.25 5.25a.75.75 0 1 1-1.06-1.06L21.44 12l-4.72-4.72a.75.75 0 0 1 0-1.06Zm-9.44 0a.75.75 0 0 1 0 1.06L2.56 12l4.72 4.72a.75.75 0 0 1-1.06 1.06L.97 12.53a.75.75 0 0 1 0-1.06l5.25-5.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" /></svg>'
+  },
+];
+
+// Recent crawler jobs for admin dashboard
+export const recentCrawlerJobs = [
+  { 
+    id: 'crawl-12879',
+    startTime: '2025-03-07T08:30:00Z',
+    endTime: '2025-03-07T09:45:00Z',
+    status: 'complete',
+    websitesUpdated: 237,
+    websitesAdded: 12,
+    errors: 3,
+  },
+  { 
+    id: 'crawl-12878',
+    startTime: '2025-03-06T08:30:00Z',
+    endTime: '2025-03-06T09:40:00Z',
+    status: 'complete',
+    websitesUpdated: 215,
+    websitesAdded: 8,
+    errors: 0,
+  },
+  { 
+    id: 'crawl-12877',
+    startTime: '2025-03-05T08:30:00Z',
+    endTime: '2025-03-05T09:50:00Z',
+    status: 'complete',
+    websitesUpdated: 243,
+    websitesAdded: 15,
+    errors: 5,
+  },
+  { 
+    id: 'crawl-12876',
+    startTime: '2025-03-04T08:30:00Z',
+    endTime: '2025-03-04T09:30:00Z',
+    status: 'complete',
+    websitesUpdated: 198,
+    websitesAdded: 7,
+    errors: 1,
+  },
+  { 
+    id: 'crawl-12875',
+    startTime: '2025-03-03T08:30:00Z',
+    endTime: '',
+    status: 'failed',
+    websitesUpdated: 42,
+    websitesAdded: 0,
+    errors: 23,
+  },
+];
+
+// Admin shortcut cards
+export const adminShortcuts = [
+  {
+    title: 'Crawler Configuration',
+    description: 'Configure crawler rules, patterns, and scheduling',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path d="M11.47 1.72a.75.75 0 0 1 1.06 0l3 3a.75.75 0 0 1-1.06 1.06l-1.72-1.72V7.5h-1.5V4.06L9.53 5.78a.75.75 0 0 1-1.06-1.06l3-3ZM11.25 7.5V15a.75.75 0 0 0 1.5 0V7.5h3.75a3 3 0 0 1 3 3v9a3 3 0 0 1-3 3h-9a3 3 0 0 1-3-3v-9a3 3 0 0 1 3-3h3.75Z" /></svg>',
+    link: '/admin/crawler-config',
+    color: 'bg-blue-100 text-blue-700',
+  },
+  {
+    title: 'Data Feeds',
+    description: 'Manage external data sources and integration',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path fill-rule="evenodd" d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" clip-rule="evenodd" /></svg>',
+    link: '/admin/data-feeds',
+    color: 'bg-green-100 text-green-700',
+  },
+  {
+    title: 'API Configuration',
+    description: 'Manage API access, tokens, and usage limits',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path fill-rule="evenodd" d="M14.447 3.026a.75.75 0 0 1 .527.921l-4.5 16.5a.75.75 0 0 1-1.448-.394l4.5-16.5a.75.75 0 0 1 .921-.527ZM16.72 6.22a.75.75 0 0 1 1.06 0l5.25 5.25a.75.75 0 0 1 0 1.06l-5.25 5.25a.75.75 0 1 1-1.06-1.06L21.44 12l-4.72-4.72a.75.75 0 0 1 0-1.06Zm-9.44 0a.75.75 0 0 1 0 1.06L2.56 12l4.72 4.72a.75.75 0 0 1-1.06 1.06L.97 12.53a.75.75 0 0 1 0-1.06l5.25-5.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" /></svg>',
+    link: '/admin/api-config',
+    color: 'bg-purple-100 text-purple-700',
+  },
+  {
+    title: 'Reports Administration',
+    description: 'Configure report templates and export settings',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path fill-rule="evenodd" d="M5.625 1.5H9a3.75 3.75 0 0 1 3.75 3.75v1.875c0 1.036.84 1.875 1.875 1.875H16.5a3.75 3.75 0 0 1 3.75 3.75v7.875c0 1.035-.84 1.875-1.875 1.875h-5.625a1.875 1.875 0 0 1-1.875-1.875V3.375c0-1.036.84-1.875 1.875-1.875ZM9.75 17.25a.75.75 0 0 0-1.5 0V18a.75.75 0 0 0 1.5 0v-.75Zm2.25-3a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 .75-.75Zm3.75-1.5a.75.75 0 0 0-1.5 0V18a.75.75 0 0 0 1.5 0v-5.25Z" clip-rule="evenodd" /></svg>',
+    link: '/admin/reports-admin',
+    color: 'bg-amber-100 text-amber-700',
+  },
+  {
+    title: 'User Management',
+    description: 'Manage user accounts, roles, and permissions',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path d="M4.5 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM14.25 8.625a3.375 3.375 0 1 1 6.75 0 3.375 3.375 0 0 1-6.75 0ZM1.5 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM17.25 19.128l-.001.144a2.25 2.25 0 0 1-.233.96 10.088 10.088 0 0 0 5.06-1.01.75.75 0 0 0 .42-.643 4.875 4.875 0 0 0-6.957-4.611 8.586 8.586 0 0 1 1.71 5.157v.003Z" /></svg>',
+    link: '/admin/user-management',
+    color: 'bg-rose-100 text-rose-700',
+  },
+  {
+    title: 'System Logs',
+    description: 'View system logs and activity history',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path fill-rule="evenodd" d="M7.502 6h7.128A3.375 3.375 0 0 1 18 9.375v9.375a3 3 0 0 0 3-3V6.108c0-1.505-1.125-2.811-2.664-2.94a48.972 48.972 0 0 0-.673-.05A3 3 0 0 0 15 1.5h-1.5a3 3 0 0 0-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6ZM13.5 3A1.5 1.5 0 0 0 12 4.5h4.5A1.5 1.5 0 0 0 15 3h-1.5Z" clip-rule="evenodd" /><path fill-rule="evenodd" d="M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 0 1 3 20.625V9.375ZM6 12a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V12Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 15a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V15Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 18a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V18Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" /></svg>',
+    link: '/admin/system-logs',
+    color: 'bg-slate-100 text-slate-700',
+  }
+];
+
+// Crawler configuration mock data
+export const crawlerConfig = {
+  general: {
+    enableCrawling: true,
+    maxConcurrentRequests: 10,
+    requestTimeout: 30000, // ms
+    respectRobotsTxt: true,
+    userAgent: 'TopPharma Crawler/1.0',
+  },
+  scheduling: {
+    frequency: 'daily',
+    startTime: '02:00', // UTC
+    daysToRun: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+    lastRun: '2025-03-07T02:00:00Z',
+    nextRun: '2025-03-08T02:00:00Z',
+  },
+  domainRules: [
+    { pattern: '*.pfizer.com', enabled: true, maxDepth: 3 },
+    { pattern: '*.merck.com', enabled: true, maxDepth: 3 },
+    { pattern: '*.novartis.com', enabled: true, maxDepth: 3 },
+    { pattern: '*.roche.com', enabled: true, maxDepth: 2 },
+    { pattern: '*.gsk.com', enabled: true, maxDepth: 3 },
+    { pattern: '*.abbvie.com', enabled: true, maxDepth: 2 },
+    { pattern: '*.sanofi.com', enabled: true, maxDepth: 3 },
+    { pattern: '*.astrazeneca.com', enabled: true, maxDepth: 3 },
+    { pattern: '*.bms.com', enabled: true, maxDepth: 3 },
+    { pattern: '*.amgen.com', enabled: true, maxDepth: 2 },
+  ],
+  dataExtractionRules: [
+    { 
+      name: 'Disclaimer detection',
+      selector: '.disclaimer, .legal-text, footer .legal, #disclaimer',
+      enabled: true
+    },
+    { 
+      name: 'Product mentions',
+      selector: '.product-name, .medication-name, [data-product]',
+      enabled: true
+    },
+    { 
+      name: 'Therapeutic area detection',
+      selector: '.therapeutic-area, .disease-area, .treatment-category',
+      enabled: true
+    },
+  ],
+};
+
+// External data feeds mock data
+export const dataFeeds = [
+  {
+    id: 'feed-1',
+    name: 'FDA Drug Approvals',
+    url: 'https://api.fda.gov/drug/approval',
+    active: true,
+    frequency: 'daily',
+    lastFetch: '2025-03-07T00:00:00Z',
+    nextFetch: '2025-03-08T00:00:00Z',
+    status: 'healthy',
+  },
+  {
+    id: 'feed-2',
+    name: 'ClinicalTrials.gov Updates',
+    url: 'https://clinicaltrials.gov/api/v2/studies',
+    active: true,
+    frequency: 'daily',
+    lastFetch: '2025-03-07T00:30:00Z',
+    nextFetch: '2025-03-08T00:30:00Z',
+    status: 'healthy',
+  },
+  {
+    id: 'feed-3',
+    name: 'SEC EDGAR Filings',
+    url: 'https://www.sec.gov/edgar/searchedgar/companysearch',
+    active: true,
+    frequency: 'weekly',
+    lastFetch: '2025-03-03T01:00:00Z',
+    nextFetch: '2025-03-10T01:00:00Z',
+    status: 'warning',
+    statusDetails: 'Rate limit warnings',
+  },
+  {
+    id: 'feed-4',
+    name: 'EMA Medicine Updates',
+    url: 'https://www.ema.europa.eu/en/medicines/api',
+    active: false,
+    frequency: 'weekly',
+    lastFetch: '2025-03-03T01:30:00Z',
+    nextFetch: null,
+    status: 'disabled',
+  },
+  {
+    id: 'feed-5',
+    name: 'WHO Essential Medicines',
+    url: 'https://apps.who.int/api/medicines',
+    active: true,
+    frequency: 'monthly',
+    lastFetch: '2025-03-01T02:00:00Z',
+    nextFetch: '2025-04-01T02:00:00Z',
+    status: 'healthy',
+  },
+];
+
+// API configuration mock data
+export const apiConfig = {
+  general: {
+    enabled: true,
+    baseUrl: 'https://api.toppharma.com/v1',
+    defaultRateLimit: 1000, // requests per day
+    requireAuthentication: true,
+  },
+  apiKeys: [
+    {
+      id: 'key-1',
+      name: 'Research Partner A',
+      key: 'tp_live_xxxxxxxxxxx',
+      created: '2025-01-15T10:00:00Z',
+      lastUsed: '2025-03-07T14:32:21Z',
+      status: 'active',
+      rateLimit: 5000,
+      endpoints: ['companies', 'products', 'websites'],
+    },
+    {
+      id: 'key-2',
+      name: 'Agency Partner B',
+      key: 'tp_live_yyyyyyyyyyy',
+      created: '2025-02-01T09:30:00Z',
+      lastUsed: '2025-03-07T08:12:45Z',
+      status: 'active',
+      rateLimit: 10000,
+      endpoints: ['companies', 'products', 'websites', 'therapeutic-areas'],
+    },
+    {
+      id: 'key-3',
+      name: 'University Research',
+      key: 'tp_live_zzzzzzzzzzz',
+      created: '2025-02-20T14:00:00Z',
+      lastUsed: '2025-03-05T11:45:03Z',
+      status: 'active',
+      rateLimit: 2000,
+      endpoints: ['companies', 'products'],
+    },
+    {
+      id: 'key-4',
+      name: 'Test Account',
+      key: 'tp_test_ttttttttttt',
+      created: '2025-03-01T15:30:00Z',
+      lastUsed: '2025-03-02T09:22:18Z',
+      status: 'revoked',
+      rateLimit: 100,
+      endpoints: ['companies'],
+    },
+  ],
+  usage: {
+    today: 8427,
+    yesterday: 7621,
+    thisWeek: 45920,
+    thisMonth: 158439,
+    peakTime: '14:00-15:00',
+    topEndpoint: 'companies',
+  },
+};
+
+// Reports configuration mock data
+export const reportsConfig = {
+  templates: [
+    {
+      id: 'template-1',
+      name: 'Company Directory',
+      description: 'Complete pharmaceutical company directory',
+      fields: ['name', 'headquarters', 'foundedYear', 'stockInfo', 'products'],
+      format: 'pdf',
+      lastGenerated: '2025-03-01T10:00:00Z',
+    },
+    {
+      id: 'template-2',
+      name: 'Product Pipeline',
+      description: 'Current product pipeline across companies',
+      fields: ['name', 'company', 'approvalStatus', 'therapeuticArea', 'phase'],
+      format: 'excel',
+      lastGenerated: '2025-03-05T14:30:00Z',
+    },
+    {
+      id: 'template-3',
+      name: 'Website Compliance Audit',
+      description: 'Audit of pharmaceutical websites for compliance',
+      fields: ['domain', 'company', 'disclaimers', 'privacyPolicy', 'cookiePolicy', 'compliance'],
+      format: 'pdf',
+      lastGenerated: '2025-03-07T09:15:00Z',
+    },
+    {
+      id: 'template-4',
+      name: 'Therapeutic Area Focus',
+      description: 'Products and companies by therapeutic area',
+      fields: ['therapeuticArea', 'companies', 'products', 'clinicalTrials'],
+      format: 'powerpoint',
+      lastGenerated: '2025-02-28T16:45:00Z',
+    },
+  ],
+  scheduledReports: [
+    {
+      id: 'schedule-1',
+      templateId: 'template-1',
+      name: 'Monthly Company Directory',
+      frequency: 'monthly',
+      dayOfMonth: 1,
+      time: '06:00',
+      recipients: ['research@example.com', 'sales@example.com'],
+      lastSent: '2025-03-01T06:00:00Z',
+      nextSend: '2025-04-01T06:00:00Z',
+    },
+    {
+      id: 'schedule-2',
+      templateId: 'template-2',
+      name: 'Weekly Pipeline Update',
+      frequency: 'weekly',
+      dayOfWeek: 'Monday',
+      time: '07:00',
+      recipients: ['product@example.com'],
+      lastSent: '2025-03-04T07:00:00Z',
+      nextSend: '2025-03-11T07:00:00Z',
+    },
+    {
+      id: 'schedule-3',
+      templateId: 'template-3',
+      name: 'Daily Compliance Check',
+      frequency: 'daily',
+      time: '00:30',
+      recipients: ['compliance@example.com', 'legal@example.com'],
+      lastSent: '2025-03-07T00:30:00Z',
+      nextSend: '2025-03-08T00:30:00Z',
+    },
+  ],
+};
+
+// User management mock data (for future use)
+export const userManagement = {
+  users: [
+    {
+      id: 'user-1',
+      email: 'admin@toppharma.com',
+      name: 'Admin User',
+      role: 'admin',
+      lastLogin: '2025-03-07T09:12:34Z',
+      status: 'active',
+      createdAt: '2024-12-01T10:00:00Z',
+    },
+    {
+      id: 'user-2',
+      email: 'analyst@toppharma.com',
+      name: 'Research Analyst',
+      role: 'editor',
+      lastLogin: '2025-03-07T08:45:12Z',
+      status: 'active',
+      createdAt: '2025-01-15T11:30:00Z',
+    },
+    {
+      id: 'user-3',
+      email: 'viewer@toppharma.com',
+      name: 'Data Viewer',
+      role: 'viewer',
+      lastLogin: '2025-03-06T14:22:05Z',
+      status: 'active',
+      createdAt: '2025-02-20T09:15:00Z',
+    },
+    {
+      id: 'user-4',
+      email: 'former@toppharma.com',
+      name: 'Former User',
+      role: 'viewer',
+      lastLogin: '2025-01-05T10:17:42Z',
+      status: 'inactive',
+      createdAt: '2025-01-01T08:00:00Z',
+    },
+  ],
+  roles: [
+    {
+      id: 'role-1',
+      name: 'admin',
+      description: 'Full system access',
+      permissions: ['read', 'write', 'delete', 'manage-users', 'manage-api'],
+    },
+    {
+      id: 'role-2',
+      name: 'editor',
+      description: 'Can edit data but not system settings',
+      permissions: ['read', 'write'],
+    },
+    {
+      id: 'role-3',
+      name: 'viewer',
+      description: 'Read-only access',
+      permissions: ['read'],
+    },
+  ],
+};
+
+// System logs mock data
+export const systemLogs = [
+  {
+    id: 'log-1',
+    timestamp: '2025-03-07T15:42:13Z',
+    level: 'info',
+    category: 'crawler',
+    message: 'Daily crawl completed successfully',
+    details: 'Processed 2,547 URLs, updated 237 entries',
+  },
+  {
+    id: 'log-2',
+    timestamp: '2025-03-07T14:30:22Z',
+    level: 'warning',
+    category: 'api',
+    message: 'Rate limit approaching for API key tp_live_xxxxxxxxxxx',
+    details: '4,872/5,000 requests used (97.4%)',
+  },
+  {
+    id: 'log-3',
+    timestamp: '2025-03-07T12:15:05Z',
+    level: 'error',
+    category: 'data-feed',
+    message: 'Connection failed to SEC EDGAR API',
+    details: 'Timeout after 30s, will retry in 1 hour',
+  },
+  {
+    id: 'log-4',
+    timestamp: '2025-03-07T10:03:41Z',
+    level: 'info',
+    category: 'user',
+    message: 'User admin@toppharma.com logged in',
+    details: 'IP: 192.168.1.1, Browser: Chrome 125.0.0',
+  },
+  {
+    id: 'log-5',
+    timestamp: '2025-03-07T09:47:18Z',
+    level: 'info',
+    category: 'report',
+    message: 'Scheduled report "Daily Compliance Check" generated',
+    details: 'Sent to 2 recipients, 15 pages, PDF format',
+  },
+  {
+    id: 'log-6',
+    timestamp: '2025-03-07T08:30:00Z',
+    level: 'info',
+    category: 'system',
+    message: 'Daily backup completed',
+    details: 'Database size: 4.2GB, Backup location: Cloud Storage',
+  },
+  {
+    id: 'log-7',
+    timestamp: '2025-03-07T02:00:00Z',
+    level: 'info',
+    category: 'crawler',
+    message: 'Daily crawl started',
+    details: 'Targeting 2,700 URLs across 47 domains',
+  },
+  {
+    id: 'log-8',
+    timestamp: '2025-03-06T23:45:12Z',
+    level: 'error',
+    category: 'data-feed',
+    message: 'Failed to parse response from FDA API',
+    details: 'Invalid JSON format, data may be corrupted',
+  },
+  {
+    id: 'log-9',
+    timestamp: '2025-03-06T18:22:37Z',
+    level: 'warning',
+    category: 'system',
+    message: 'High CPU usage detected',
+    details: '85% utilization for over 10 minutes',
+  },
+  {
+    id: 'log-10',
+    timestamp: '2025-03-06T16:05:51Z',
+    level: 'info',
+    category: 'api',
+    message: 'New API key generated',
+    details: 'Key ID: tp_live_nnnnnnnnnn, For: "New Research Partner"',
+  },
+]; 

--- a/src/pages/admin/api-config.astro
+++ b/src/pages/admin/api-config.astro
@@ -1,0 +1,339 @@
+---
+/**
+ * API Configuration
+ * 
+ * Admin page for managing API settings, keys, and usage limits.
+ */
+import Layout from '../../layouts/Layout.astro';
+import Card from '../../components/atoms/Card.astro';
+import { apiConfig } from '../../data/admin';
+
+// Format date
+const formatDate = (dateString: string): string => {
+  if (!dateString) return '--';
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+};
+
+// Format large numbers
+const formatNumber = (num: number): string => {
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};
+---
+
+<Layout title="API Configuration | Admin | Top Pharma">
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div class="flex items-center">
+          <a href="/admin" class="mr-2 text-gray-400 hover:text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+              <path fill-rule="evenodd" d="M11.03 3.97a.75.75 0 0 1 0 1.06l-6.22 6.22H21a.75.75 0 0 1 0 1.5H4.81l6.22 6.22a.75.75 0 1 1-1.06 1.06l-7.5-7.5a.75.75 0 0 1 0-1.06l7.5-7.5a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          <h1 class="text-3xl font-bold tracking-tight text-gray-900">API Configuration</h1>
+        </div>
+      </div>
+    </header>
+    <main class="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      
+      <!-- General Settings -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">General Settings</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <label for="api-status" class="block text-sm font-medium text-gray-700">API Status</label>
+                <div class="mt-2">
+                  <select id="api-status" name="api-status" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="enabled" selected={apiConfig.general.enabled}>Enabled</option>
+                    <option value="disabled" selected={!apiConfig.general.enabled}>Disabled</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="base-url" class="block text-sm font-medium text-gray-700">Base URL</label>
+                <div class="mt-2">
+                  <input type="text" name="base-url" id="base-url" value={apiConfig.general.baseUrl} class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="default-rate" class="block text-sm font-medium text-gray-700">Default Rate Limit (requests/day)</label>
+                <div class="mt-2">
+                  <input type="number" name="default-rate" id="default-rate" value={apiConfig.general.defaultRateLimit} class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="require-auth" class="block text-sm font-medium text-gray-700">Require Authentication</label>
+                <div class="mt-2">
+                  <select id="require-auth" name="require-auth" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="true" selected={apiConfig.general.requireAuthentication}>Yes</option>
+                    <option value="false" selected={!apiConfig.general.requireAuthentication}>No</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Reset
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Changes
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- API Keys -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">API Keys</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Create New API Key
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">API Key</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rate Limit</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Used</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {apiConfig.apiKeys.map((key) => (
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{key.name}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 font-mono">
+                        {key.key.substring(0, 8) + '...'}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                          key.status === 'active' 
+                            ? 'bg-green-100 text-green-800' 
+                            : 'bg-red-100 text-red-800'
+                        }`}>
+                          {key.status}
+                        </span>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatNumber(key.rateLimit)} / day
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatDate(key.created)}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatDate(key.lastUsed)}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">View</button>
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                        <button type="button" class="text-red-600 hover:text-red-900">
+                          {key.status === 'active' ? 'Revoke' : 'Activate'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- API Key Details Form -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Create/Edit API Key</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div class="sm:col-span-2">
+                <label for="key-name" class="block text-sm font-medium text-gray-700">Partner Name</label>
+                <div class="mt-1">
+                  <input type="text" name="key-name" id="key-name" placeholder="e.g., Research Partner A" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="key-rate" class="block text-sm font-medium text-gray-700">Rate Limit (requests/day)</label>
+                <div class="mt-1">
+                  <input type="number" name="key-rate" id="key-rate" placeholder="5000" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="key-status" class="block text-sm font-medium text-gray-700">Status</label>
+                <div class="mt-1">
+                  <select id="key-status" name="key-status" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="active">Active</option>
+                    <option value="revoked">Revoked</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label class="block text-sm font-medium text-gray-700">Allowed Endpoints</label>
+                <div class="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  {['companies', 'products', 'websites', 'therapeutic-areas', 'reports'].map((endpoint) => (
+                    <div class="flex items-center">
+                      <input 
+                        id={`endpoint-${endpoint}`} 
+                        name={`endpoint-${endpoint}`} 
+                        type="checkbox" 
+                        class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      >
+                      <label for={`endpoint-${endpoint}`} class="ml-2 text-sm text-gray-700">{endpoint}</label>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="key-notes" class="block text-sm font-medium text-gray-700">Notes</label>
+                <div class="mt-1">
+                  <textarea id="key-notes" name="key-notes" rows="3" placeholder="Additional notes about this API key or partner..." class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"></textarea>
+                </div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Cancel
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save API Key
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- API Usage Stats -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">API Usage Statistics</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-5 sm:grid-cols-3">
+              <div class="bg-gray-50 rounded-lg p-4">
+                <h3 class="text-sm font-medium text-gray-500">Today</h3>
+                <p class="mt-1 text-2xl font-semibold text-gray-900">{formatNumber(apiConfig.usage.today)}</p>
+                <p class="mt-1 text-sm text-gray-500">API requests</p>
+              </div>
+              
+              <div class="bg-gray-50 rounded-lg p-4">
+                <h3 class="text-sm font-medium text-gray-500">This Week</h3>
+                <p class="mt-1 text-2xl font-semibold text-gray-900">{formatNumber(apiConfig.usage.thisWeek)}</p>
+                <p class="mt-1 text-sm text-gray-500">API requests</p>
+              </div>
+              
+              <div class="bg-gray-50 rounded-lg p-4">
+                <h3 class="text-sm font-medium text-gray-500">This Month</h3>
+                <p class="mt-1 text-2xl font-semibold text-gray-900">{formatNumber(apiConfig.usage.thisMonth)}</p>
+                <p class="mt-1 text-sm text-gray-500">API requests</p>
+              </div>
+            </div>
+            
+            <div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2">
+              <div>
+                <h3 class="text-sm font-medium text-gray-500">Most Used Endpoint</h3>
+                <p class="mt-1 text-lg font-medium text-gray-900">{apiConfig.usage.topEndpoint}</p>
+              </div>
+              
+              <div>
+                <h3 class="text-sm font-medium text-gray-500">Peak Usage Time</h3>
+                <p class="mt-1 text-lg font-medium text-gray-900">{apiConfig.usage.peakTime} UTC</p>
+              </div>
+            </div>
+            
+            <div class="mt-6">
+              <h3 class="text-sm font-medium text-gray-500 mb-2">Daily Usage Trend (Placeholder)</h3>
+              <div class="bg-gray-100 border border-gray-200 rounded-lg h-64 flex items-center justify-center">
+                <p class="text-gray-500">API usage chart would appear here</p>
+              </div>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Webhook Configuration -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Webhook Configuration</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <p class="text-sm text-gray-500 mb-4">
+              Configure webhooks to notify external services about API events.
+            </p>
+            
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div class="sm:col-span-2">
+                <label for="webhook-url" class="block text-sm font-medium text-gray-700">Webhook URL</label>
+                <div class="mt-1">
+                  <input type="url" name="webhook-url" id="webhook-url" placeholder="https://example.com/webhook" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label class="block text-sm font-medium text-gray-700">Webhook Events</label>
+                <div class="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  <div class="flex items-center">
+                    <input id="event-rate-limit" name="event-rate-limit" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <label for="event-rate-limit" class="ml-2 text-sm text-gray-700">Rate Limit Approaching</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input id="event-key-created" name="event-key-created" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <label for="event-key-created" class="ml-2 text-sm text-gray-700">API Key Created</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input id="event-key-revoked" name="event-key-revoked" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <label for="event-key-revoked" class="ml-2 text-sm text-gray-700">API Key Revoked</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input id="event-high-traffic" name="event-high-traffic" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <label for="event-high-traffic" class="ml-2 text-sm text-gray-700">High Traffic Alert</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input id="event-error-spike" name="event-error-spike" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <label for="event-error-spike" class="ml-2 text-sm text-gray-700">Error Rate Spike</label>
+                  </div>
+                </div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Cancel
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Webhook
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-gray-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2">
+                Test Webhook
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+    </main>
+  </div>
+</Layout> 

--- a/src/pages/admin/crawler-config.astro
+++ b/src/pages/admin/crawler-config.astro
@@ -1,0 +1,267 @@
+---
+/**
+ * Crawler Configuration
+ * 
+ * Admin page for configuring website crawler rules, patterns, and scheduling.
+ */
+import Layout from '../../layouts/Layout.astro';
+import Card from '../../components/atoms/Card.astro';
+import { crawlerConfig } from '../../data/admin';
+
+// Format date
+const formatDate = (dateString: string): string => {
+  if (!dateString) return '--';
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+};
+---
+
+<Layout title="Crawler Configuration | Admin | Top Pharma">
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div class="flex items-center">
+          <a href="/admin" class="mr-2 text-gray-400 hover:text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+              <path fill-rule="evenodd" d="M11.03 3.97a.75.75 0 0 1 0 1.06l-6.22 6.22H21a.75.75 0 0 1 0 1.5H4.81l6.22 6.22a.75.75 0 1 1-1.06 1.06l-7.5-7.5a.75.75 0 0 1 0-1.06l7.5-7.5a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          <h1 class="text-3xl font-bold tracking-tight text-gray-900">Crawler Configuration</h1>
+        </div>
+      </div>
+    </header>
+    <main class="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      
+      <!-- General Settings -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">General Settings</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <label for="enable-crawling" class="block text-sm font-medium text-gray-700">Enable Crawling</label>
+                <div class="mt-2">
+                  <select id="enable-crawling" name="enable-crawling" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="true" selected={crawlerConfig.general.enableCrawling}>Enabled</option>
+                    <option value="false" selected={!crawlerConfig.general.enableCrawling}>Disabled</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="max-concurrent" class="block text-sm font-medium text-gray-700">Max Concurrent Requests</label>
+                <div class="mt-2">
+                  <input type="number" name="max-concurrent" id="max-concurrent" value={crawlerConfig.general.maxConcurrentRequests} class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="request-timeout" class="block text-sm font-medium text-gray-700">Request Timeout (ms)</label>
+                <div class="mt-2">
+                  <input type="number" name="request-timeout" id="request-timeout" value={crawlerConfig.general.requestTimeout} class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="respect-robots" class="block text-sm font-medium text-gray-700">Respect robots.txt</label>
+                <div class="mt-2">
+                  <select id="respect-robots" name="respect-robots" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="true" selected={crawlerConfig.general.respectRobotsTxt}>Yes</option>
+                    <option value="false" selected={!crawlerConfig.general.respectRobotsTxt}>No</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="user-agent" class="block text-sm font-medium text-gray-700">User Agent</label>
+                <div class="mt-2">
+                  <input type="text" name="user-agent" id="user-agent" value={crawlerConfig.general.userAgent} class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Reset
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Changes
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Scheduling Settings -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Scheduling</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <label for="frequency" class="block text-sm font-medium text-gray-700">Crawl Frequency</label>
+                <div class="mt-2">
+                  <select id="frequency" name="frequency" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="hourly">Hourly</option>
+                    <option value="daily" selected={crawlerConfig.scheduling.frequency === 'daily'}>Daily</option>
+                    <option value="weekly" selected={crawlerConfig.scheduling.frequency === 'weekly'}>Weekly</option>
+                    <option value="monthly" selected={crawlerConfig.scheduling.frequency === 'monthly'}>Monthly</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="start-time" class="block text-sm font-medium text-gray-700">Start Time (UTC)</label>
+                <div class="mt-2">
+                  <input type="time" name="start-time" id="start-time" value={crawlerConfig.scheduling.startTime} class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label class="block text-sm font-medium text-gray-700">Days to Run</label>
+                <div class="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-7">
+                  {['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'].map((day) => (
+                    <div class="flex items-center">
+                      <input 
+                        id={`day-${day.toLowerCase()}`} 
+                        name={`day-${day.toLowerCase()}`} 
+                        type="checkbox" 
+                        checked={crawlerConfig.scheduling.daysToRun.includes(day)} 
+                        class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      >
+                      <label for={`day-${day.toLowerCase()}`} class="ml-2 text-sm text-gray-700">{day}</label>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              
+              <div>
+                <label class="block text-sm font-medium text-gray-700">Last Run</label>
+                <div class="mt-2 text-sm text-gray-900">{formatDate(crawlerConfig.scheduling.lastRun)}</div>
+              </div>
+              
+              <div>
+                <label class="block text-sm font-medium text-gray-700">Next Scheduled Run</label>
+                <div class="mt-2 text-sm text-gray-900">{formatDate(crawlerConfig.scheduling.nextRun)}</div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Reset Schedule
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Schedule
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-amber-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2">
+                Run Crawler Now
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Domain Rules -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Domain Rules</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Add New Rule
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pattern</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Max Depth</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {crawlerConfig.domainRules.map((rule) => (
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{rule.pattern}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                          rule.enabled 
+                            ? 'bg-green-100 text-green-800' 
+                            : 'bg-red-100 text-red-800'
+                        }`}>
+                          {rule.enabled ? 'Enabled' : 'Disabled'}
+                        </span>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{rule.maxDepth}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                        <button type="button" class="text-red-600 hover:text-red-900">Delete</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Data Extraction Rules -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Data Extraction Rules</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Add New Extraction Rule
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rule Name</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">CSS Selector</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {crawlerConfig.dataExtractionRules.map((rule) => (
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{rule.name}</td>
+                      <td class="px-6 py-4 text-sm text-gray-500">{rule.selector}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                          rule.enabled 
+                            ? 'bg-green-100 text-green-800' 
+                            : 'bg-red-100 text-red-800'
+                        }`}>
+                          {rule.enabled ? 'Enabled' : 'Disabled'}
+                        </span>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                        <button type="button" class="text-red-600 hover:text-red-900">Delete</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </main>
+  </div>
+</Layout> 

--- a/src/pages/admin/data-feeds.astro
+++ b/src/pages/admin/data-feeds.astro
@@ -1,0 +1,274 @@
+---
+/**
+ * Data Feeds Configuration
+ * 
+ * Admin page for managing external data sources like FDA, ClinicalTrials.gov, and other APIs.
+ */
+import Layout from '../../layouts/Layout.astro';
+import Card from '../../components/atoms/Card.astro';
+import { dataFeeds } from '../../data/admin';
+
+// Format date
+const formatDate = (dateString: string): string => {
+  if (!dateString) return '--';
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+};
+
+// Get status badge color
+const getStatusColor = (status: string): string => {
+  switch (status) {
+    case 'healthy':
+      return 'bg-green-100 text-green-800';
+    case 'warning':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'error':
+      return 'bg-red-100 text-red-800';
+    case 'disabled':
+      return 'bg-gray-100 text-gray-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+---
+
+<Layout title="Data Feeds | Admin | Top Pharma">
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div class="flex items-center">
+          <a href="/admin" class="mr-2 text-gray-400 hover:text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+              <path fill-rule="evenodd" d="M11.03 3.97a.75.75 0 0 1 0 1.06l-6.22 6.22H21a.75.75 0 0 1 0 1.5H4.81l6.22 6.22a.75.75 0 1 1-1.06 1.06l-7.5-7.5a.75.75 0 0 1 0-1.06l7.5-7.5a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          <h1 class="text-3xl font-bold tracking-tight text-gray-900">Data Feeds</h1>
+        </div>
+      </div>
+    </header>
+    <main class="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      
+      <!-- Overview -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">External Data Sources</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <p class="text-sm text-gray-500 mb-4">
+              Configure and manage external data sources that are used to enrich our database. These sources are polled on a schedule to keep our information up-to-date.
+            </p>
+            
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Add New Data Feed
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">URL</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Frequency</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Fetch</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Next Fetch</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {dataFeeds.map((feed) => (
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{feed.name}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <a href={feed.url} target="_blank" class="text-primary-600 hover:text-primary-900">
+                          {feed.url.length > 30 ? feed.url.substring(0, 30) + '...' : feed.url}
+                        </a>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${getStatusColor(feed.status)}`}>
+                          {feed.status}
+                        </span>
+                        {feed.statusDetails && (
+                          <span class="block text-xs text-gray-500 mt-1">{feed.statusDetails}</span>
+                        )}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {feed.frequency}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatDate(feed.lastFetch)}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatDate(feed.nextFetch)}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Fetch Now</button>
+                        <button type="button" class="text-red-600 hover:text-red-900">
+                          {feed.active ? 'Disable' : 'Enable'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Data Feed Details -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Add/Edit Data Feed</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div class="sm:col-span-2">
+                <label for="feed-name" class="block text-sm font-medium text-gray-700">Feed Name</label>
+                <div class="mt-1">
+                  <input type="text" name="feed-name" id="feed-name" placeholder="e.g., FDA Drug Approvals" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="feed-url" class="block text-sm font-medium text-gray-700">API URL</label>
+                <div class="mt-1">
+                  <input type="url" name="feed-url" id="feed-url" placeholder="https://api.example.com/endpoint" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="feed-frequency" class="block text-sm font-medium text-gray-700">Frequency</label>
+                <div class="mt-1">
+                  <select id="feed-frequency" name="feed-frequency" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="hourly">Hourly</option>
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                    <option value="monthly">Monthly</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="feed-status" class="block text-sm font-medium text-gray-700">Status</label>
+                <div class="mt-1">
+                  <select id="feed-status" name="feed-status" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="active">Active</option>
+                    <option value="disabled">Disabled</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="feed-auth" class="block text-sm font-medium text-gray-700">Authentication (Optional)</label>
+                <div class="mt-1">
+                  <textarea id="feed-auth" name="feed-auth" rows="3" placeholder="API Key or Authentication Details" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"></textarea>
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="feed-mapping" class="block text-sm font-medium text-gray-700">Data Mapping</label>
+                <div class="mt-1">
+                  <textarea id="feed-mapping" name="feed-mapping" rows="5" placeholder="JSON mapping configuration" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm font-mono"></textarea>
+                </div>
+                <p class="mt-2 text-sm text-gray-500">Define how fields from the external API map to our database schema.</p>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Cancel
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Data Feed
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-gray-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2">
+                Test Connection
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Fetch History -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Fetch History</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <p class="text-sm text-gray-500 mb-4">
+              Recent data fetch operations and their status.
+            </p>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data Feed</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Records Updated</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">FDA Drug Approvals</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 7, 2025 12:00 AM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                      <span class="inline-flex rounded-full px-2 text-xs font-semibold leading-5 bg-green-100 text-green-800">
+                        Success
+                      </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">42</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">3.2s</td>
+                  </tr>
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">ClinicalTrials.gov Updates</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 7, 2025 12:30 AM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                      <span class="inline-flex rounded-full px-2 text-xs font-semibold leading-5 bg-green-100 text-green-800">
+                        Success
+                      </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">187</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">12.7s</td>
+                  </tr>
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">SEC EDGAR Filings</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 6, 2025 11:45 PM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                      <span class="inline-flex rounded-full px-2 text-xs font-semibold leading-5 bg-red-100 text-red-800">
+                        Failed
+                      </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">0</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">30.0s</td>
+                  </tr>
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">WHO Essential Medicines</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 6, 2025 2:00 PM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                      <span class="inline-flex rounded-full px-2 text-xs font-semibold leading-5 bg-green-100 text-green-800">
+                        Success
+                      </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">3</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">1.5s</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+    </main>
+  </div>
+</Layout> 

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,152 @@
+---
+/**
+ * Admin Dashboard
+ * 
+ * Main administrator dashboard page showing system statistics, 
+ * recent crawler activity, and admin shortcut cards.
+ */
+import Layout from '../../layouts/Layout.astro';
+import Card from '../../components/atoms/Card.astro';
+import { systemStats, recentCrawlerJobs, adminShortcuts } from '../../data/admin';
+
+// Format number with commas
+const formatNumber = (num: number): string => {
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};
+
+// Format date
+const formatDate = (dateString: string): string => {
+  if (!dateString) return '--';
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+};
+---
+
+<Layout title="Admin Dashboard | Top Pharma">
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <h1 class="text-3xl font-bold tracking-tight text-gray-900">Admin Dashboard</h1>
+      </div>
+    </header>
+    <main class="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      
+      <!-- Welcome Panel -->
+      <div class="bg-white p-6 rounded-lg shadow-sm mb-6">
+        <h2 class="text-lg font-semibold text-gray-900">Welcome, Admin</h2>
+        <p class="mt-1 text-gray-500">
+          Last login: Today at 9:12 AM | System status: Operational
+        </p>
+      </div>
+      
+      <!-- System Stats -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">System Statistics</h2>
+        <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+          {systemStats.map((stat) => (
+            <Card>
+              <div class="px-4 py-5 sm:p-6">
+                <div class="flex items-center">
+                  <div class="flex-shrink-0 rounded-md bg-primary-50 p-3">
+                    <span set:html={stat.icon} />
+                  </div>
+                  <div class="ml-5 w-0 flex-1">
+                    <dt class="text-sm font-medium text-gray-500 truncate">{stat.label}</dt>
+                    <dd class="flex items-baseline">
+                      <div class="text-2xl font-semibold text-gray-900">
+                        {formatNumber(stat.value)}
+                      </div>
+                      <div class={`ml-2 flex items-baseline text-sm font-semibold ${
+                        stat.trend === 'up' ? 'text-green-600' : 'text-red-600'
+                      }`}>
+                        {stat.change}
+                      </div>
+                    </dd>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+      
+      <!-- Recent Crawler Activity -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Crawler Activity</h2>
+        <Card>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead>
+                <tr>
+                  <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Job ID</th>
+                  <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Start Time</th>
+                  <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">End Time</th>
+                  <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Updated</th>
+                  <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Added</th>
+                  <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Errors</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                {recentCrawlerJobs.map((job) => (
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{job.id}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(job.startTime)}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(job.endTime)}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                      <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                        job.status === 'complete' 
+                          ? 'bg-green-100 text-green-800' 
+                          : 'bg-red-100 text-red-800'
+                      }`}>
+                        {job.status}
+                      </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{job.websitesUpdated}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{job.websitesAdded}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <span class={job.errors > 0 ? 'text-red-600 font-medium' : 'text-gray-500'}>
+                        {job.errors}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Admin Shortcuts -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Admin Tools</h2>
+        <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {adminShortcuts.map((shortcut) => (
+            <a href={shortcut.link} class="block">
+              <Card hover={true}>
+                <div class="px-4 py-5 sm:p-6">
+                  <div class="flex items-start">
+                    <div class={`flex-shrink-0 rounded-md p-3 ${shortcut.color}`}>
+                      <span set:html={shortcut.icon} />
+                    </div>
+                    <div class="ml-4">
+                      <h3 class="text-lg font-medium text-gray-900">{shortcut.title}</h3>
+                      <p class="mt-1 text-sm text-gray-500">{shortcut.description}</p>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            </a>
+          ))}
+        </div>
+      </div>
+      
+    </main>
+  </div>
+</Layout> 

--- a/src/pages/admin/reports-admin.astro
+++ b/src/pages/admin/reports-admin.astro
@@ -1,0 +1,325 @@
+---
+/**
+ * Reports Administration
+ * 
+ * Admin page for managing report templates, scheduled exports, and report generation.
+ */
+import Layout from '../../layouts/Layout.astro';
+import Card from '../../components/atoms/Card.astro';
+import { reportsConfig } from '../../data/admin';
+
+// Format date
+const formatDate = (dateString: string): string => {
+  if (!dateString) return '--';
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+};
+---
+
+<Layout title="Reports Administration | Admin | Top Pharma">
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div class="flex items-center">
+          <a href="/admin" class="mr-2 text-gray-400 hover:text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+              <path fill-rule="evenodd" d="M11.03 3.97a.75.75 0 0 1 0 1.06l-6.22 6.22H21a.75.75 0 0 1 0 1.5H4.81l6.22 6.22a.75.75 0 1 1-1.06 1.06l-7.5-7.5a.75.75 0 0 1 0-1.06l7.5-7.5a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          <h1 class="text-3xl font-bold tracking-tight text-gray-900">Reports Administration</h1>
+        </div>
+      </div>
+    </header>
+    <main class="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      
+      <!-- Report Templates -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Report Templates</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <p class="text-sm text-gray-500 mb-4">
+              Configure report templates that determine what data is included in reports and how it's formatted.
+            </p>
+            
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Create New Template
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Format</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fields</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Generated</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {reportsConfig.templates.map((template) => (
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{template.name}</td>
+                      <td class="px-6 py-4 text-sm text-gray-500">{template.description}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 uppercase">{template.format}</td>
+                      <td class="px-6 py-4 text-sm text-gray-500">
+                        {template.fields.slice(0, 3).join(', ')}
+                        {template.fields.length > 3 && '...'}
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(template.lastGenerated)}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Generate</button>
+                        <button type="button" class="text-red-600 hover:text-red-900">Delete</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Scheduled Reports -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Scheduled Reports</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <p class="text-sm text-gray-500 mb-4">
+              Schedule automatic generation and distribution of reports.
+            </p>
+            
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Create New Schedule
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Template</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Frequency</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Recipients</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Sent</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Next Send</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {reportsConfig.scheduledReports.map((schedule) => {
+                    const template = reportsConfig.templates.find(t => t.id === schedule.templateId);
+                    return (
+                      <tr>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{schedule.name}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{template?.name || '--'}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          {schedule.frequency === 'monthly' 
+                            ? `Monthly (${schedule.dayOfMonth})` 
+                            : schedule.frequency === 'weekly'
+                              ? `Weekly (${schedule.dayOfWeek})`
+                              : schedule.frequency}
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-500">
+                          {schedule.recipients.length} recipient{schedule.recipients.length !== 1 ? 's' : ''}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(schedule.lastSent)}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(schedule.nextSend)}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                          <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Run Now</button>
+                          <button type="button" class="text-red-600 hover:text-red-900">Disable</button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Template Editor -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Template Editor</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div class="sm:col-span-2">
+                <label for="template-name" class="block text-sm font-medium text-gray-700">Template Name</label>
+                <div class="mt-1">
+                  <input type="text" name="template-name" id="template-name" placeholder="e.g., Company Directory" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="template-description" class="block text-sm font-medium text-gray-700">Description</label>
+                <div class="mt-1">
+                  <input type="text" name="template-description" id="template-description" placeholder="e.g., Complete pharmaceutical company directory" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="template-format" class="block text-sm font-medium text-gray-700">Format</label>
+                <div class="mt-1">
+                  <select id="template-format" name="template-format" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="pdf">PDF</option>
+                    <option value="excel">Excel</option>
+                    <option value="csv">CSV</option>
+                    <option value="json">JSON</option>
+                    <option value="powerpoint">PowerPoint</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="template-header" class="block text-sm font-medium text-gray-700">Include Header</label>
+                <div class="mt-1">
+                  <select id="template-header" name="template-header" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="true">Yes</option>
+                    <option value="false">No</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label class="block text-sm font-medium text-gray-700">Include Fields</label>
+                <div class="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  {['name', 'headquarters', 'foundedYear', 'stockInfo', 'products', 'therapeuticArea', 'approvalStatus', 'phase', 'domain', 'company', 'disclaimers', 'privacyPolicy', 'cookiePolicy', 'compliance'].map((field) => (
+                    <div class="flex items-center">
+                      <input 
+                        id={`field-${field}`} 
+                        name={`field-${field}`} 
+                        type="checkbox" 
+                        class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      >
+                      <label for={`field-${field}`} class="ml-2 text-sm text-gray-700">{field}</label>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="template-filter" class="block text-sm font-medium text-gray-700">Filter Criteria (JSON)</label>
+                <div class="mt-1">
+                  <textarea id="template-filter" name="template-filter" rows="3" placeholder='{"therapeuticArea": "oncology"}' class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm font-mono"></textarea>
+                </div>
+                <p class="mt-1 text-sm text-gray-500">Optional filters to apply when generating this report.</p>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Cancel
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Template
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-amber-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2">
+                Preview
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Schedule Editor -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Schedule Editor</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div class="sm:col-span-2">
+                <label for="schedule-name" class="block text-sm font-medium text-gray-700">Schedule Name</label>
+                <div class="mt-1">
+                  <input type="text" name="schedule-name" id="schedule-name" placeholder="e.g., Monthly Company Directory" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="schedule-template" class="block text-sm font-medium text-gray-700">Template</label>
+                <div class="mt-1">
+                  <select id="schedule-template" name="schedule-template" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    {reportsConfig.templates.map((template) => (
+                      <option value={template.id}>{template.name}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="schedule-frequency" class="block text-sm font-medium text-gray-700">Frequency</label>
+                <div class="mt-1">
+                  <select id="schedule-frequency" name="schedule-frequency" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                    <option value="monthly">Monthly</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="schedule-day" class="block text-sm font-medium text-gray-700">Day</label>
+                <div class="mt-1">
+                  <select id="schedule-day" name="schedule-day" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="Monday">Monday</option>
+                    <option value="Tuesday">Tuesday</option>
+                    <option value="Wednesday">Wednesday</option>
+                    <option value="Thursday">Thursday</option>
+                    <option value="Friday">Friday</option>
+                    <option value="Saturday">Saturday</option>
+                    <option value="Sunday">Sunday</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="schedule-time" class="block text-sm font-medium text-gray-700">Time (UTC)</label>
+                <div class="mt-1">
+                  <input type="time" name="schedule-time" id="schedule-time" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="schedule-recipients" class="block text-sm font-medium text-gray-700">Recipients</label>
+                <div class="mt-1">
+                  <textarea id="schedule-recipients" name="schedule-recipients" rows="3" placeholder="Email addresses (one per line)" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"></textarea>
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label for="schedule-message" class="block text-sm font-medium text-gray-700">Email Message</label>
+                <div class="mt-1">
+                  <textarea id="schedule-message" name="schedule-message" rows="3" placeholder="Optional message to include in the email" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"></textarea>
+                </div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Cancel
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Schedule
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+    </main>
+  </div>
+</Layout> 

--- a/src/pages/admin/system-logs.astro
+++ b/src/pages/admin/system-logs.astro
@@ -1,0 +1,303 @@
+---
+/**
+ * System Logs
+ * 
+ * Admin page for viewing system logs, activity history, and error reports.
+ */
+import Layout from '../../layouts/Layout.astro';
+import Card from '../../components/atoms/Card.astro';
+import { systemLogs } from '../../data/admin';
+
+// Format date
+const formatDate = (dateString: string): string => {
+  if (!dateString) return '--';
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+};
+
+// Get log level color
+const getLevelColor = (level: string): string => {
+  switch (level) {
+    case 'info':
+      return 'bg-blue-100 text-blue-800';
+    case 'warning':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'error':
+      return 'bg-red-100 text-red-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+
+// Get log category color
+const getCategoryColor = (category: string): string => {
+  switch (category) {
+    case 'crawler':
+      return 'bg-purple-100 text-purple-800';
+    case 'api':
+      return 'bg-indigo-100 text-indigo-800';
+    case 'data-feed':
+      return 'bg-green-100 text-green-800';
+    case 'system':
+      return 'bg-gray-100 text-gray-800';
+    case 'user':
+      return 'bg-blue-100 text-blue-800';
+    case 'report':
+      return 'bg-amber-100 text-amber-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+---
+
+<Layout title="System Logs | Admin | Top Pharma">
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div class="flex items-center">
+          <a href="/admin" class="mr-2 text-gray-400 hover:text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+              <path fill-rule="evenodd" d="M11.03 3.97a.75.75 0 0 1 0 1.06l-6.22 6.22H21a.75.75 0 0 1 0 1.5H4.81l6.22 6.22a.75.75 0 1 1-1.06 1.06l-7.5-7.5a.75.75 0 0 1 0-1.06l7.5-7.5a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          <h1 class="text-3xl font-bold tracking-tight text-gray-900">System Logs</h1>
+        </div>
+      </div>
+    </header>
+    <main class="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      
+      <!-- Log Filters -->
+      <div class="mb-6">
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div>
+                <label for="filter-level" class="block text-sm font-medium text-gray-700">Log Level</label>
+                <select id="filter-level" name="filter-level" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                  <option value="all">All Levels</option>
+                  <option value="info">Info</option>
+                  <option value="warning">Warning</option>
+                  <option value="error">Error</option>
+                </select>
+              </div>
+              
+              <div>
+                <label for="filter-category" class="block text-sm font-medium text-gray-700">Category</label>
+                <select id="filter-category" name="filter-category" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                  <option value="all">All Categories</option>
+                  <option value="crawler">Crawler</option>
+                  <option value="api">API</option>
+                  <option value="data-feed">Data Feed</option>
+                  <option value="user">User</option>
+                  <option value="system">System</option>
+                  <option value="report">Report</option>
+                </select>
+              </div>
+              
+              <div>
+                <label for="filter-date" class="block text-sm font-medium text-gray-700">Date Range</label>
+                <select id="filter-date" name="filter-date" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                  <option value="today">Today</option>
+                  <option value="yesterday">Yesterday</option>
+                  <option value="week">Last 7 Days</option>
+                  <option value="month">Last 30 Days</option>
+                  <option value="custom">Custom Range</option>
+                </select>
+              </div>
+            </div>
+            
+            <div class="mt-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Reset
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Apply Filters
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-gray-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2">
+                Export Logs
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- System Logs -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">System Activity</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Level</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Message</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Details</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {systemLogs.map((log) => (
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(log.timestamp)}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${getLevelColor(log.level)}`}>
+                          {log.level}
+                        </span>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${getCategoryColor(log.category)}`}>
+                          {log.category}
+                        </span>
+                      </td>
+                      <td class="px-6 py-4 text-sm text-gray-900">{log.message}</td>
+                      <td class="px-6 py-4 text-sm text-gray-500">{log.details}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            
+            <div class="mt-4 flex items-center justify-between">
+              <div class="text-sm text-gray-500">
+                Showing <span class="font-medium">10</span> of <span class="font-medium">234</span> logs
+              </div>
+              
+              <div class="flex space-x-2">
+                <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                  Previous
+                </button>
+                <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                  Next
+                </button>
+              </div>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Log Settings -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Log Settings</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-3">
+              <div>
+                <label for="log-retention" class="block text-sm font-medium text-gray-700">Log Retention</label>
+                <select id="log-retention" name="log-retention" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                  <option value="7">7 days</option>
+                  <option value="14">14 days</option>
+                  <option value="30" selected>30 days</option>
+                  <option value="90">90 days</option>
+                  <option value="365">1 year</option>
+                </select>
+              </div>
+              
+              <div>
+                <label for="log-level" class="block text-sm font-medium text-gray-700">Minimum Log Level</label>
+                <select id="log-level" name="log-level" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                  <option value="debug">Debug</option>
+                  <option value="info" selected>Info</option>
+                  <option value="warning">Warning</option>
+                  <option value="error">Error</option>
+                </select>
+              </div>
+              
+              <div>
+                <label for="external-logging" class="block text-sm font-medium text-gray-700">External Logging</label>
+                <select id="external-logging" name="external-logging" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                  <option value="disabled">Disabled</option>
+                  <option value="file">File System</option>
+                  <option value="cloud" selected>Cloud Storage</option>
+                  <option value="monitoring">Monitoring Service</option>
+                </select>
+              </div>
+            </div>
+            
+            <div class="mt-6">
+              <label for="error-webhook" class="block text-sm font-medium text-gray-700">Error Notification Webhook URL</label>
+              <div class="mt-1">
+                <input type="url" name="error-webhook" id="error-webhook" value="https://hooks.slack.com/services/XXXXX/YYYYY/ZZZZZ" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+              </div>
+              <p class="mt-1 text-xs text-gray-500">Send error-level log notifications to this webhook URL (e.g., Slack)</p>
+            </div>
+            
+            <div class="mt-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Reset
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Settings
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                Clear All Logs
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- System Health -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">System Health</h2>
+        <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+          <Card>
+            <div class="px-4 py-5 sm:p-6">
+              <div class="flex flex-col items-center">
+                <h3 class="text-lg font-medium text-gray-900">CPU Usage</h3>
+                <div class="mt-1 h-16 w-16 rounded-full bg-green-100 flex items-center justify-center text-green-600 font-bold text-xl">
+                  24%
+                </div>
+                <p class="mt-2 text-sm text-gray-500">Healthy</p>
+              </div>
+            </div>
+          </Card>
+          
+          <Card>
+            <div class="px-4 py-5 sm:p-6">
+              <div class="flex flex-col items-center">
+                <h3 class="text-lg font-medium text-gray-900">Memory</h3>
+                <div class="mt-1 h-16 w-16 rounded-full bg-green-100 flex items-center justify-center text-green-600 font-bold text-xl">
+                  38%
+                </div>
+                <p class="mt-2 text-sm text-gray-500">2.1GB / 5.5GB</p>
+              </div>
+            </div>
+          </Card>
+          
+          <Card>
+            <div class="px-4 py-5 sm:p-6">
+              <div class="flex flex-col items-center">
+                <h3 class="text-lg font-medium text-gray-900">Disk Space</h3>
+                <div class="mt-1 h-16 w-16 rounded-full bg-yellow-100 flex items-center justify-center text-yellow-600 font-bold text-xl">
+                  78%
+                </div>
+                <p class="mt-2 text-sm text-gray-500">78.3GB / 100GB</p>
+              </div>
+            </div>
+          </Card>
+          
+          <Card>
+            <div class="px-4 py-5 sm:p-6">
+              <div class="flex flex-col items-center">
+                <h3 class="text-lg font-medium text-gray-900">Database</h3>
+                <div class="mt-1 h-16 w-16 rounded-full bg-green-100 flex items-center justify-center text-green-600 font-bold text-xl">
+                  OK
+                </div>
+                <p class="mt-2 text-sm text-gray-500">Response: 12ms</p>
+              </div>
+            </div>
+          </Card>
+        </div>
+      </div>
+      
+    </main>
+  </div>
+</Layout> 

--- a/src/pages/admin/user-management.astro
+++ b/src/pages/admin/user-management.astro
@@ -1,0 +1,353 @@
+---
+/**
+ * User Management
+ * 
+ * Admin page for managing user accounts, roles, and permissions.
+ */
+import Layout from '../../layouts/Layout.astro';
+import Card from '../../components/atoms/Card.astro';
+import { userManagement } from '../../data/admin';
+
+// Format date
+const formatDate = (dateString: string): string => {
+  if (!dateString) return '--';
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+};
+---
+
+<Layout title="User Management | Admin | Top Pharma">
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div class="flex items-center">
+          <a href="/admin" class="mr-2 text-gray-400 hover:text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+              <path fill-rule="evenodd" d="M11.03 3.97a.75.75 0 0 1 0 1.06l-6.22 6.22H21a.75.75 0 0 1 0 1.5H4.81l6.22 6.22a.75.75 0 1 1-1.06 1.06l-7.5-7.5a.75.75 0 0 1 0-1.06l7.5-7.5a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          <h1 class="text-3xl font-bold tracking-tight text-gray-900">User Management</h1>
+        </div>
+      </div>
+    </header>
+    <main class="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      
+      <!-- User List -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Users</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Add New User
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Login</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {userManagement.users.map((user) => (
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{user.name}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{user.email}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                          user.role === 'admin' 
+                            ? 'bg-purple-100 text-purple-800' 
+                            : user.role === 'editor'
+                              ? 'bg-blue-100 text-blue-800' 
+                              : 'bg-gray-100 text-gray-800'
+                        }`}>
+                          {user.role}
+                        </span>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm">
+                        <span class={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                          user.status === 'active' 
+                            ? 'bg-green-100 text-green-800' 
+                            : 'bg-red-100 text-red-800'
+                        }`}>
+                          {user.status}
+                        </span>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(user.lastLogin)}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(user.createdAt)}</td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                        <button type="button" class="text-red-600 hover:text-red-900">
+                          {user.status === 'active' ? 'Deactivate' : 'Activate'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Roles & Permissions -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Roles & Permissions</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="mb-4 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Add New Role
+              </button>
+            </div>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Permissions</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Users</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  {userManagement.roles.map((role) => {
+                    const usersWithRole = userManagement.users.filter(user => user.role === role.name && user.status === 'active');
+                    return (
+                      <tr>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{role.name}</td>
+                        <td class="px-6 py-4 text-sm text-gray-500">{role.description}</td>
+                        <td class="px-6 py-4 text-sm text-gray-500">
+                          {role.permissions.map((permission, index) => (
+                            <span>
+                              <span class="inline-flex rounded-full px-2 text-xs font-semibold leading-5 bg-gray-100 text-gray-800">
+                                {permission}
+                              </span>
+                              {index < role.permissions.length - 1 ? ' ' : ''}
+                            </span>
+                          ))}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          {usersWithRole.length}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          <button type="button" class="text-primary-600 hover:text-primary-900 mr-3">Edit</button>
+                          <button type="button" class="text-red-600 hover:text-red-900">Delete</button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- User Editor Form -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Add/Edit User</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <label for="user-name" class="block text-sm font-medium text-gray-700">Full Name</label>
+                <div class="mt-1">
+                  <input type="text" name="user-name" id="user-name" placeholder="e.g., John Doe" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="user-email" class="block text-sm font-medium text-gray-700">Email</label>
+                <div class="mt-1">
+                  <input type="email" name="user-email" id="user-email" placeholder="e.g., john@example.com" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="user-role" class="block text-sm font-medium text-gray-700">Role</label>
+                <div class="mt-1">
+                  <select id="user-role" name="user-role" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    {userManagement.roles.map((role) => (
+                      <option value={role.name}>{role.name}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="user-status" class="block text-sm font-medium text-gray-700">Status</label>
+                <div class="mt-1">
+                  <select id="user-status" name="user-status" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                    <option value="active">Active</option>
+                    <option value="inactive">Inactive</option>
+                  </select>
+                </div>
+              </div>
+              
+              <div>
+                <label for="user-password" class="block text-sm font-medium text-gray-700">Password</label>
+                <div class="mt-1">
+                  <input type="password" name="user-password" id="user-password" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="user-password-confirm" class="block text-sm font-medium text-gray-700">Confirm Password</label>
+                <div class="mt-1">
+                  <input type="password" name="user-password-confirm" id="user-password-confirm" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label class="block text-sm font-medium text-gray-700">Additional Options</label>
+                <div class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <div class="flex items-center">
+                    <input id="send-welcome" name="send-welcome" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <label for="send-welcome" class="ml-2 text-sm text-gray-700">Send welcome email</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input id="require-reset" name="require-reset" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <label for="require-reset" class="ml-2 text-sm text-gray-700">Require password reset on first login</label>
+                  </div>
+                </div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Cancel
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save User
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Role Editor Form -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Add/Edit Role</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <label for="role-name" class="block text-sm font-medium text-gray-700">Role Name</label>
+                <div class="mt-1">
+                  <input type="text" name="role-name" id="role-name" placeholder="e.g., manager" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div>
+                <label for="role-description" class="block text-sm font-medium text-gray-700">Description</label>
+                <div class="mt-1">
+                  <input type="text" name="role-description" id="role-description" placeholder="e.g., Can edit data but not system settings" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                </div>
+              </div>
+              
+              <div class="sm:col-span-2">
+                <label class="block text-sm font-medium text-gray-700">Permissions</label>
+                <div class="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  {['read', 'write', 'delete', 'manage-users', 'manage-api', 'view-reports', 'create-reports', 'access-admin'].map((permission) => (
+                    <div class="flex items-center">
+                      <input 
+                        id={`permission-${permission}`} 
+                        name={`permission-${permission}`} 
+                        type="checkbox" 
+                        class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      >
+                      <label for={`permission-${permission}`} class="ml-2 text-sm text-gray-700">{permission}</label>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+            
+            <div class="mt-6 flex justify-end">
+              <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Cancel
+              </button>
+              <button type="button" class="ml-3 inline-flex items-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+                Save Role
+              </button>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+      <!-- Activity Log -->
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">User Activity Log</h2>
+        <Card>
+          <div class="px-4 py-5 sm:p-6">
+            <p class="text-sm text-gray-500 mb-4">
+              Recent user activity and authentication events.
+            </p>
+            
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Event</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">IP Address</th>
+                    <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Details</th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 7, 2025 9:12 AM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">admin@toppharma.com</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Login</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">192.168.1.1</td>
+                    <td class="px-6 py-4 text-sm text-gray-500">Browser: Chrome 125.0.0</td>
+                  </tr>
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 7, 2025 8:45 AM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">analyst@toppharma.com</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Login</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">192.168.1.2</td>
+                    <td class="px-6 py-4 text-sm text-gray-500">Browser: Firefox 115.0.0</td>
+                  </tr>
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 6, 2025 6:30 PM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">admin@toppharma.com</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Logout</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">192.168.1.1</td>
+                    <td class="px-6 py-4 text-sm text-gray-500">Session duration: 4h 12m</td>
+                  </tr>
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Mar 6, 2025 2:18 PM</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">admin@toppharma.com</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">Login</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">192.168.1.1</td>
+                    <td class="px-6 py-4 text-sm text-gray-500">Browser: Chrome 125.0.0</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Card>
+      </div>
+      
+    </main>
+  </div>
+</Layout> 


### PR DESCRIPTION
- Create main admin dashboard page with welcome panel, system stats, and shortcut cards
- Add extensive mock data for admin functions in admin.ts
- Implement crawler configuration page for website crawler settings
- Add data feeds management page for external data sources
- Create API configuration page for managing API keys and settings
- Add reports administration page for report generation and scheduling
- Implement user management page for user accounts and permissions
- Create system logs page for viewing system activity
- Fix syntax error in data-feeds.astro by recreating the file with proper structure

This provides a comprehensive foundation for the administrator section with placeholder pages for all key functionality, following the structure outlined in the build plan.