### PR TITLE
feat: add entity type support and color mapping for layouts

### DIFF
--- a/src/layouts/EntityDetailLayout.astro
+++ b/src/layouts/EntityDetailLayout.astro
@@ -28,7 +28,16 @@ interface Props {
   logoUrl?: string | null;
   entityName: string;
   entitySubtitle?: string;
+  entityType?: 'company' | 'product' | 'therapeuticArea' | 'website'; // Optional entity type for defaults
 }
+
+// Color mapping for entity types to provide consistent colors
+const colorMap = {
+  company: { from: 'blue-500', to: 'blue-600' },
+  product: { from: 'green-600', to: 'green-700' },
+  therapeuticArea: { from: 'amber-500', to: 'amber-600' },
+  website: { from: 'purple-500', to: 'purple-600' }
+};
 
 const {
   title,
@@ -41,8 +50,13 @@ const {
   activeTab,
   logoUrl,
   entityName,
-  entitySubtitle
+  entitySubtitle,
+  entityType
 } = Astro.props;
+
+// If entity type is provided but gradients aren't, use the default colors
+const effectiveGradientFrom = gradientFrom || (entityType && colorMap[entityType]?.from) || 'primary-500';
+const effectiveGradientTo = gradientTo || (entityType && colorMap[entityType]?.to) || 'primary-600';
 ---
 
 <DashboardLayout
@@ -51,11 +65,28 @@ const {
   currentPath={currentPath}
   breadcrumbs={breadcrumbs}
 >
+  <style define:vars={{
+    entityColorFrom: `var(--color-${effectiveGradientFrom})`, 
+    entityColorTo: `var(--color-${effectiveGradientTo})`,
+    entityColorLight: `var(--color-${effectiveGradientFrom.split('-')[0]}-100)`,
+    entityColorText: `var(--color-${effectiveGradientFrom.split('-')[0]}-600)`
+  }}>
+    .entity-header-bg {
+      background-image: linear-gradient(to right, var(--entityColorFrom), var(--entityColorTo));
+    }
+    .entity-logo-bg {
+      background-color: var(--entityColorLight);
+    }
+    .entity-logo-text {
+      color: var(--entityColorText);
+    }
+  </style>
+
   <div class="space-y-6">
     <!-- Entity Header -->
     <div class="relative">
       <!-- Header Background -->
-      <div class={`h-48 w-full bg-gradient-to-r from-${gradientFrom} to-${gradientTo} relative overflow-hidden shadow-md opacity-90`}>
+      <div class="h-48 w-full entity-header-bg relative overflow-hidden shadow-md opacity-90">
         <!-- Background pattern or decoration could go here -->
       </div>
       
@@ -69,8 +100,8 @@ const {
                 {logoUrl ? (
                   <img src={logoUrl} alt={`${entityName} logo`} class="max-w-full max-h-full p-2" />
                 ) : (
-                  <div class={`bg-${gradientFrom}-100 w-full h-full flex items-center justify-center`}>
-                    <span class={`text-4xl font-bold text-${gradientFrom}-600`}>{entityName.charAt(0)}</span>
+                  <div class="entity-logo-bg w-full h-full flex items-center justify-center">
+                    <span class="entity-logo-text text-4xl font-bold">{entityName.charAt(0)}</span>
                   </div>
                 )}
               </div>

--- a/src/pages/companies/[slug].astro
+++ b/src/pages/companies/[slug].astro
@@ -119,6 +119,7 @@ const activeTab = Astro.url.searchParams.get('tab') || 'overview';
   logoUrl={logoUrl}
   entityName={company.name}
   entitySubtitle={company.description}
+  entityType="company"
 >
   <!-- Action Buttons -->
   <div slot="action-buttons" class="flex space-x-3">

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -141,6 +141,7 @@ export const prerender = false;
   logoUrl={product.imageUrl}
   entityName={product.name}
   entitySubtitle={product.genericName}
+  entityType="product"
 >
   <!-- Action Buttons -->
   <div slot="action-buttons" class="flex space-x-2">

--- a/src/pages/therapeutic-areas/[slug].astro
+++ b/src/pages/therapeutic-areas/[slug].astro
@@ -119,6 +119,7 @@ const therapeuticAreaIcon = `<svg xmlns="http://www.w3.org/2000/svg" class="h-10
   logoUrl={therapeuticArea.iconPath}
   entityName={therapeuticArea.name}
   entitySubtitle={therapeuticArea.description}
+  entityType="therapeuticArea"
 >
   <!-- Overview Tab Content -->
   <div slot="overview">

--- a/src/pages/websites/[slug].astro
+++ b/src/pages/websites/[slug].astro
@@ -113,6 +113,7 @@ const websiteIcon = `<svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 te
   logoUrl={website.screenshotUrl}
   entityName={website.name || website.url}
   entitySubtitle={website.url}
+  entityType="website"
 >
   <!-- Action Buttons -->
   <div slot="action-buttons" class="flex space-x-3">


### PR DESCRIPTION
- Introduced optional `entityType` prop in `EntityDetailLayout.astro` to handle different entity types (company, product, therapeuticArea, website).
- Implemented a color mapping system to provide consistent gradient colors based on the entity type.
- Updated relevant pages for companies, products, therapeutic areas, and websites to pass the new `entityType` prop, enhancing visual consistency across the application.

These changes improve the layout's adaptability and maintainability by centralizing color logic and supporting multiple entity types.